### PR TITLE
Edge case fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(FetchContent)
 FetchContent_Declare(
         endstone
         GIT_REPOSITORY https://github.com/EndstoneMC/endstone.git
-        GIT_TAG v0.10.17
+        GIT_TAG v0.11.0
 )
 FetchContent_MakeAvailable(endstone)
 

--- a/include/event_listener.h
+++ b/include/event_listener.h
@@ -17,6 +17,9 @@ public:
     static bool canTriggerEvent(const std::string& playername);
 
     // Added
+    static void edgeCaseOnPlayerJoin(const endstone::PlayerJoinEvent& event);
+    static void edgeCaseOnPlayerQuit(const endstone::PlayerQuitEvent& event);
+
     static void onPlayerDropItem(const endstone::PlayerDropItemEvent& event);
 
     static void onBlockBreak(const endstone::BlockBreakEvent& event);

--- a/src/tianyan_plugin.cpp
+++ b/src/tianyan_plugin.cpp
@@ -337,6 +337,8 @@ void TianyanPlugin::onEnable()
     registerEvent<endstone::ActorDeathEvent>(EventListener::onActorDie);
     registerEvent<endstone::PlayerPickupItemEvent>(EventListener::onPlayPickup);
     registerEvent<endstone::PlayerDeathEvent>(EventListener::onPlayerDie);
+    registerEvent<endstone::PlayerJoinEvent>(EventListener::edgeCaseOnPlayerJoin);
+    registerEvent<endstone::PlayerQuitEvent>(EventListener::edgeCaseOnPlayerQuit);
     registerEvent<endstone::PlayerDropItemEvent>(EventListener::onPlayerDropItem);
     registerEvent(&EventListener::onPlayerJoin, *eventListener_);
     registerEvent(&EventListener::onPlayerSendMSG, *eventListener_);


### PR DESCRIPTION
PR to fix this issue where if the player drops an item before disconnecting, then connect back into the server, player.getLocation() will fail and segfault the entire server.

The fix is to simply add joined player list (using edgeCaseOnPlayerJoin/Quit), so if the player is not joined yet, ignore them. This is an emergency fix I made to fix this issue as quickly as possible.

![0aab7c25-1800-4933-910f-729eef6564a0](https://github.com/user-attachments/assets/72464e57-f710-40de-9957-31d527586953)
