### PR TITLE
fix: resolve build errors on CI (SQLite3 and missing dist)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ FetchContent_MakeAvailable(cpp_httplib)
 set(WEBUI_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/WebUI-Next/dist")
 set(WEBUI_RESOURCE_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/webui_resources.h")
 
+if (NOT EXISTS "${WEBUI_SOURCE_DIR}/index.html")
+    message(WARNING "WebUI-Next/dist/index.html not found. Generating a dummy index.html for build to succeed. Please build WebUI-Next to get the real UI.")
+    file(MAKE_DIRECTORY "${WEBUI_SOURCE_DIR}")
+    file(WRITE "${WEBUI_SOURCE_DIR}/index.html" "<html><body><h1>WebUI not built. Please run pnpm build in WebUI-Next.</h1></body></html>")
+endif()
+
 add_custom_command(
     OUTPUT ${WEBUI_RESOURCE_OUTPUT}
     COMMAND ${CMAKE_COMMAND}
@@ -124,7 +130,17 @@ set_target_properties(world_inspector PROPERTIES
 )
 
 # SQLite3
-find_package(SQLite3 REQUIRED)
+find_package(SQLite3 QUIET)
+if(NOT SQLite3_FOUND)
+    message(STATUS "SQLite3 not found by find_package, falling back to FetchContent...")
+    FetchContent_Declare(
+        sqlite3
+        GIT_REPOSITORY https://github.com/azadkuh/sqlite-amalgamation.git
+        GIT_TAG master
+    )
+    FetchContent_MakeAvailable(sqlite3)
+    add_library(SQLite3::SQLite3 ALIAS sqlite3)
+endif()
 
 file(GLOB PLUGIN_SOURCES
         CONFIGURE_DEPENDS
@@ -164,7 +180,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
         nlohmann_json::nlohmann_json
-        SQLite::SQLite3
+        SQLite3::SQLite3
         fmt::fmt-header-only
         endstone_inventoryui
         rust_mysql


### PR DESCRIPTION
This PR fixes two build issues that occur on automated CI systems:

1. **Linux Build Failure**: The CMake build on Linux fails with a ninja error because it cannot find `WebUI-Next/dist/index.html`, which is not committed to the repository. This PR adds a fallback that automatically creates a dummy `index.html` if it is missing, allowing the C++ plugin to successfully compile without breaking the build pipeline.
2. **Windows Build Failure**: The build on Windows fails because the default `windows-2022` GitHub runner does not have SQLite3 installed, causing `find_package(SQLite3)` to abort. This PR implements a fallback that automatically downloads and statically links SQLite3 via `FetchContent` if it cannot be found on the system.
3. Also fixed the `SQLite::SQLite3 is deprecated` warnings in CMake.