### PR TITLE
fix: normalize WebUI database result keys

### DIFF
--- a/WebUI/server.py
+++ b/WebUI/server.py
@@ -299,9 +299,10 @@ class Database:
 
     def fetchall(self, cursor) -> list[dict]:
         """以 dict 列表形式返回所有结果行。"""
-        if self.db_type == "sqlite":
-            return [dict(row) for row in cursor.fetchall()]
-        return cursor.fetchall()
+        return [
+            {str(key).lower(): value for key, value in dict(row).items()}
+            for row in cursor.fetchall()
+        ]
 
     def fetchone(self, cursor) -> Optional[dict]:
         """以 dict 形式返回第一行。"""
@@ -805,11 +806,11 @@ async def get_db_info(x_secret: str = Header(None)):
             row = db.fetchone(cursor)
             total_rows = int(row["cnt"]) if row else 0
         else:
-            cursor = db.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = ?", [db.database])
+            cursor = db.execute("SELECT table_name AS table_name FROM information_schema.tables WHERE table_schema = ?", [db.database])
             tables = [row["table_name"] for row in db.fetchall(cursor)]
 
             cursor = db.execute("""
-                SELECT index_name FROM information_schema.statistics
+                SELECT index_name AS index_name FROM information_schema.statistics
                 WHERE table_schema = ? AND table_name = 'LOGDATA'
                 GROUP BY index_name
             """, [db.database])


### PR DESCRIPTION
## Problem

When the WebUI runs against MySQL, `/api/db_info` can crash with a 500 response. A production NAS log captured the failure immediately after WebUI startup:

```text
/vol1/1000/bedrock_server/logs/mc-screen.log
524056: 2026-07-06 12:55:29,419 - tianyan_plugin - INFO - Start WebUI Service，127.0.0.1:8098
524057: ERROR:uvicorn.error:Exception in ASGI application
524104:   File "/vol1/1000/bedrock_server/plugins/tianyan_data/WebUI/server.py", line 809, in get_db_info
524105:     tables = [row["table_name"] for row in db.fetchall(cursor)]
524107:   File "/vol1/1000/bedrock_server/plugins/tianyan_data/WebUI/server.py", line 809, in <listcomp>
524108:     tables = [row["table_name"] for row in db.fetchall(cursor)]
524110: KeyError: 'table_name'
```

The live config was using MySQL (`database_type=mysql`) with WebUI enabled, so this was not a SQLite path.

## Root cause

The WebUI `Database` wrapper promises dict-like rows for both SQLite and MySQL, but it did not normalize key names for MySQL `DictCursor` results. MySQL metadata queries against `information_schema` can return keys such as `TABLE_NAME` / `INDEX_NAME`, while `/api/db_info` expects lowercase `table_name` / `index_name`.

## Fix

- Normalize all `Database.fetchall()` row keys to lowercase for both SQLite and MySQL.
- Add explicit aliases for the MySQL `information_schema.tables` and `information_schema.statistics` fields used by `/api/db_info`.

This keeps the API code independent of backend-specific result-key casing and prevents the same class of bug in future MySQL queries.

## Verification

- `python3 -m py_compile WebUI/server.py`
- NAS temporary WebUI instance on the same MySQL config returned `HTTP 200` from `/api/db_info`.
- NAS live WebUI after deploying the patch returned:

```text
HTTP 200
tables ['LOGDATA']
indexes 7
columns 14
total_rows 16053689
```

A full scan of the current NAS `mc-screen.log` found only the three old pre-fix `KeyError: 'table_name'` occurrences.